### PR TITLE
docs: oppdater README til å speile faktisk stack og oppsett

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,59 @@
 # tms-utkast-frontend
 
-Frontend for tilgang til liste med utkast
+[![Deploy main](https://github.com/navikt/tms-utkast-frontend/actions/workflows/deploy-main.yaml/badge.svg)](https://github.com/navikt/tms-utkast-frontend/actions/workflows/deploy-main.yaml)
+![Astro](https://img.shields.io/badge/Astro-BC52EE?logo=astro&logoColor=white)
+![React](https://img.shields.io/badge/React-149ECA?logo=react&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
+![Biome](https://img.shields.io/badge/Biome-60A5FA?logo=biome&logoColor=white)
+![Vitest](https://img.shields.io/badge/Vitest-6E9F18?logo=vitest&logoColor=white)
+![Playwright](https://img.shields.io/badge/Playwright-2EAD33?logo=playwright&logoColor=white)
 
-# Kom i gang
+## Formålet med repoet
 
-1. Installer dependencies med npm run install
-2. Bygg tms-utkast-frontend ved å kjøre npm run build
-3. Start hono mockserver med npm run mock
-4. Med mockserver kjørende i egen terminal, start appen lokalt ved å kjøre npm run dev i et nytt terminalvindu
-4. Appen nås på http://localhost:4321/utkast
+Dette er frontend-flaten som viser innbyggeres påbegynte utkast på Min side på nav.no. Hovedmålgruppen er innbyggere som er logget inn via ID-porten. Når brukeren åpner utkast-siden, henter appen listen over utkast og presenterer dem som lenkekort, slik at brukeren kan fortsette på en søknad eller et skjema de har startet på. Hvis brukeren ikke har noen utkast, vises en egen tom-tilstand, og ved feil mot backend vises en feilmelding.
 
-# Henvendelser
+Appen er en server-renderet Astro-app med React-øyer, og kjører bak nav-dekoratøren på `/minside/utkast`.
 
-Spørsmål knyttet til koden eller prosjektet kan stilles som issues her på github.
+## Arkitektur
 
-## For NAV-ansatte
+```mermaid
+flowchart LR
+    bruker["Innbygger\n(nettleser)"]
+    frontend["tms-utkast-frontend\n(Astro SSR)"]
+    backend["tms-utkast\n(backend)"]
+    dekorator["nav-dekoratoren"]
 
-Interne henvendelser kan sendes via Slack i kanalen #team-minside.
+    bruker -->|ID-porten-innlogging| frontend
+    frontend -->|TokenX OBO-token| backend
+    frontend -->|henter header/footer| dekorator
+```
+
+Innkommende forespørsler valideres i Astro-middleware (`src/middleware/index.ts`) med `@navikt/oasis`. Mot `tms-utkast` veksles brukerens token til et on-behalf-of-token via TokenX før utkast hentes.
+
+## Miljøer
+
+| Miljø | URL |
+|---|---|
+| Produksjon | https://www.nav.no/minside/utkast |
+| Dev (intern) | https://www.intern.dev.nav.no/minside/utkast |
+| Dev (ansatt) | https://www.ansatt.dev.nav.no/minside/utkast |
+
+## Backend-referanse
+
+### [tms-utkast](https://github.com/navikt/tms-utkast)
+
+Leverer innbyggerens påbegynte utkast som vises på Min side.
+
+- **GET** `/v2/utkast`
+
+Kallet gjøres server-side med et TokenX OBO-token (audience `<cluster>:min-side:tms-utkast`).
+
+## Utvikling
+
+Lokalt nås appen på http://localhost:4321/minside/utkast, med en Hono-mockserver som spiller rollen til `tms-utkast`-backenden. I lokal modus hoppes innlogging og token-veksling over.
+
+Tilgjengelige kommandoer (bygg, test, mock og kjøring) finner du med `pnpm run` — det viser den til enhver tid oppdaterte listen over `scripts` i `package.json`. Repoet bruker Node 24 og pnpm.
+
+## For Nav-ansatte
+
+Spørsmål knyttet til koden eller prosjektet kan stilles som issues her på GitHub. Interne henvendelser kan rettes til [#team-minside på Slack](https://nav-it.slack.com/app_redirect?channel=team-minside).


### PR DESCRIPTION
## Hva
Skriver om README basert på faktisk repo-innhold i stedet for den gamle, korte malen.

## Endringer
- **Badges** for faktisk stack (Astro, React, TypeScript, Biome, Vitest, Playwright) + `deploy-main`-workflow.
- **Formål** beskriver flaten, målgruppen (innlogget innbygger) og tilstandene: utkastliste, tom-tilstand og feilvisning.
- **Arkitekturdiagram** (Mermaid) med ID-porten-innlogging, TokenX OBO mot `tms-utkast` og nav-dekoratøren — verifisert mot `src/middleware/index.ts`, `src/utils/token.ts` og `nais/`.
- **Miljølenker** hentet fra `ingresses` i nais-manifestene (prod + dev intern/ansatt).
- **Backend-referanse** til [tms-utkast](https://github.com/navikt/tms-utkast) med `GET /v2/utkast`.
- **Utvikling** peker til `pnpm run` for ferske kommandoer i stedet for å kopiere konkrete kommandoer.

## Rettelser mot gammel README
- Gammel README sa `npm`; workflows og lockfile bruker **pnpm**.
- Gammel lokal URL var `http://localhost:4321/utkast`; `base` i `astro.config.mjs` er `/minside/utkast`, så URL er rettet til **http://localhost:4321/minside/utkast**.

## Kontekst
Generert med `readme-update`-skillen, kryssjekket mot kode, `nais/` og `.github/workflows/`.