### PR TITLE
test(e2e): utvid Playwright-dekning med page object, a11y og responsivt

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,28 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import { UtkastPage } from "./pages/utkast.page";
+
+test.describe("Tilgjengelighet (a11y)", () => {
+  test("forsiden har ingen WCAG-brudd", async ({ page }) => {
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+    await utkast.expectAtLeastOneUtkast();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test("feilsiden har ingen WCAG-brudd", async ({ page }) => {
+    await page.goto("/minside/utkast/nb/error");
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/error.spec.ts
+++ b/e2e/error.spec.ts
@@ -4,6 +4,19 @@ test.describe("Feilsiden", () => {
   test("viser en feiloverskrift", async ({ page }) => {
     await page.goto("/minside/utkast/nb/error");
 
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+      "Noe gikk galt!",
+    );
+  });
+
+  test("viser feilmelding og lenke til Min side", async ({ page }) => {
+    await page.goto("/minside/utkast/nb/error");
+
+    await expect(
+      page.getByText("Vi har for øyeblikket tekniske problemer", {
+        exact: false,
+      }),
+    ).toBeVisible();
+    await expect(page.getByRole("link", { name: "Min side" })).toBeVisible();
   });
 });

--- a/e2e/index.spec.ts
+++ b/e2e/index.spec.ts
@@ -1,19 +1,76 @@
 import { expect, test } from "@playwright/test";
+import { UtkastPage } from "./pages/utkast.page";
 
 test.describe("Utkast-forsiden", () => {
   test("viser hovedoverskrift", async ({ page }) => {
-    await page.goto("/minside/utkast/nb");
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
 
-    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(utkast.heading).toHaveText("Utkast");
+  });
+
+  test("viser brødsmulesti til Min side", async ({ page }) => {
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+
+    await expect(
+      utkast.breadcrumb.getByRole("link", { name: "Min side" }),
+    ).toBeVisible();
+  });
+
+  test("viser ingressteksten", async ({ page }) => {
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+
+    await expect(
+      page.getByText(
+        "Her kan du fortsette på skjemaer du ikke har sendt til oss ennå",
+      ),
+    ).toBeVisible();
   });
 
   test("viser utkast fra api-et", async ({ page }) => {
-    await page.goto("/minside/utkast/nb");
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
 
     await expect(
-      page
-        .getByRole("link", { name: "Søknad om dagpenger, permittert" })
-        .first(),
+      utkast.utkastLinkByTitle("Søknad om dagpenger, permittert"),
     ).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("viser opprettet-dato og slette-tag på et utkast", async ({ page }) => {
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+    await utkast.expectAtLeastOneUtkast();
+
+    await expect(
+      page.getByText(/Du startet på utkastet\s+23\.03\.2020/).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Utkastet slettes\s+23\.04\.2020/).first(),
+    ).toBeVisible();
+  });
+
+  test("hvert utkast lenker videre", async ({ page }) => {
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+    await utkast.expectAtLeastOneUtkast();
+
+    const firstLink = utkast.utkastLinks().first();
+    await expect(firstLink).toHaveAttribute("href", /https?:\/\//);
+  });
+});
+
+test.describe("Språkstøtte", () => {
+  test("viser engelsk innhold på /en", async ({ page }) => {
+    const utkast = new UtkastPage(page, "en");
+    await utkast.goto();
+
+    await expect(utkast.heading).toHaveText("Drafts");
+    await expect(
+      page.getByText(
+        "Here you can continue with the forms you have not yet submitted to us",
+      ),
+    ).toBeVisible();
   });
 });

--- a/e2e/pages/utkast.page.ts
+++ b/e2e/pages/utkast.page.ts
@@ -1,0 +1,36 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+import type { Language } from "../../src/language/language";
+
+const BASE_PATH = "/minside/utkast";
+
+export class UtkastPage {
+  readonly heading: Locator;
+  readonly breadcrumb: Locator;
+  readonly utkastList: Locator;
+
+  constructor(
+    private readonly page: Page,
+    private readonly language: Language = "nb",
+  ) {
+    this.heading = page.getByRole("heading", { level: 1 });
+    this.breadcrumb = page.getByRole("navigation");
+    this.utkastList = page.getByRole("list").first();
+  }
+
+  async goto() {
+    await this.page.goto(`${BASE_PATH}/${this.language}`);
+    await expect(this.heading).toBeVisible();
+  }
+
+  utkastLinks(): Locator {
+    return this.page.getByRole("link", { name: /søknad om/i });
+  }
+
+  utkastLinkByTitle(title: string): Locator {
+    return this.page.getByRole("link", { name: title }).first();
+  }
+
+  async expectAtLeastOneUtkast() {
+    await expect(this.utkastLinks().first()).toBeVisible({ timeout: 20_000 });
+  }
+}

--- a/e2e/responsive.spec.ts
+++ b/e2e/responsive.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+import { UtkastPage } from "./pages/utkast.page";
+
+test.describe("Responsivt design", () => {
+  test("viser utkast på mobil viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+
+    await expect(utkast.heading).toBeVisible();
+    await utkast.expectAtLeastOneUtkast();
+  });
+
+  test("viser utkast på desktop viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    const utkast = new UtkastPage(page);
+    await utkast.goto();
+
+    await expect(utkast.heading).toBeVisible();
+    await utkast.expectAtLeastOneUtkast();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "19.2.7"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
     "@biomejs/biome": "2.4.16",
     "@hono/node-server": "2.0.4",
     "@playwright/test": "1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
       '@biomejs/biome':
         specifier: 2.4.16
         version: 2.4.16
@@ -178,6 +181,11 @@ packages:
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
 
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -291,24 +299,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
@@ -779,89 +791,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -914,6 +942,9 @@ packages:
       '@types/react': ^17.0.30 || ^18 || ^19
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@navikt/ds-tokens@8.13.0':
     resolution: {integrity: sha512-rtdyubAcoP4f8onbtghjjCyL5UlOLvz9eK53bR7CJbUUTEGovebgoUwB6S10LFGj3BktFe7m91Vu6vtsCpmEZw==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/8.13.0/63a58bf567e0a95c1ced6a3d7356de06c19a2457}
@@ -924,6 +955,9 @@ packages:
     peerDependencies:
       html-react-parser: '>=5.x'
       react: '>=17.x'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@navikt/oasis@4.1.4':
     resolution: {integrity: sha512-v+LW8V5CTiHkfIXhceQ8RXRtrBktCK8wSFYmiR6hmzl9CJRYRLUpFC7YbLiC7jwHIuLHKUyl+Zawf8zQm6fDeQ==, tarball: https://npm.pkg.github.com/download/@navikt/oasis/4.1.4/0d9c93820b9b6d93b1bd9da134feb95461ad8a47}
@@ -1000,66 +1034,79 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
@@ -1349,6 +1396,10 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3194,6 +3245,11 @@ snapshots:
     dependencies:
       yaml: 2.8.4
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3732,11 +3788,12 @@ snapshots:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@navikt/aksel-icons': 8.12.0
       '@navikt/ds-tokens': 8.13.0
-      '@types/react': 19.2.17
       date-fns: 4.4.0
       react: 19.2.7
       react-day-picker: 9.14.0(react@19.2.7)
       react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@navikt/ds-tokens@8.13.0': {}
 
@@ -3745,6 +3802,7 @@ snapshots:
       csp-header: 6.3.1
       html-react-parser: 5.2.17(@types/react@19.2.17)(react@19.2.7)
       js-cookie: 3.0.5
+    optionalDependencies:
       react: 19.2.7
 
   '@navikt/oasis@4.1.4':
@@ -4262,6 +4320,8 @@ snapshots:
       - yaml
 
   atomic-sleep@1.0.0: {}
+
+  axe-core@4.11.4: {}
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
## Hva
Utvider Playwright E2E-suiten for utkast-forsiden, basert på `playwright-testing`-skillen.

### Endringer
- **Page object**: `e2e/pages/utkast.page.ts` (overskrift, brødsmulesti, utkastlenker, locale-aware `goto`)
- **Forsidetester** (`index.spec.ts`): brødsmulesti til Min side, ingresstekst, utkastkort fra API, opprettet-dato + slette-tag, lenke-`href`, og engelsk locale (`/en`)
- **Feilside** (`error.spec.ts`): feilmeldingstekst + Min side-lenke
- **Tilgjengelighet** (`accessibility.spec.ts`): axe-core (wcag2a/2aa/21aa) på forside og feilside
- **Responsivt** (`responsive.spec.ts`): mobil (375×812) og desktop (1280×800)
- Ny dev-avhengighet: `@axe-core/playwright`

## Testing
`pnpm test:e2e` → 13/13 grønne. CI installerer allerede Chromium og kjører `pnpm test:e2e`, så ingen workflow-endringer.

> [!NOTE]
> Datotekstene bruker `\s+` fordi Aksel `LinkCard.Description` rendrer dobbelt mellomrom mellom etikett og dato.