### PR TITLE
Enable Vite build sourcemaps

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,11 @@ export default defineConfig({
   build: {
     assetsPrefix: "https://cdn.nav.no/min-side/tms-utkast-frontend",
   },
+  vite: {
+    build: {
+      sourcemap: true,
+    },
+  },
   integrations: [react()],
   logger: {
     entrypoint: "@navikt/astro-logger",


### PR DESCRIPTION
Source maps make it easier to debug production builds by mapping minified code back to the original source. This adds `vite.build.sourcemap: true` to `astro.config.mjs` so source maps are emitted alongside the bundled assets.