### PR TITLE
chore: align biome config with tms-min-side

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,33 +1,12 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
-  "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
-  "files": { "ignoreUnknown": false },
-  "formatter": {
-    "enabled": true,
-    "formatWithErrors": false,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineEnding": "lf",
-    "lineWidth": 80,
-    "attributePosition": "auto",
-    "bracketSameLine": false,
-    "bracketSpacing": true,
-    "expand": "auto",
-    "useEditorconfig": true
+  "$schema": "https://biomejs.dev/schemas/latest/schema.json",
+  "files": {
+    "includes": ["**", "!.github/skills/**/scripts"]
   },
-  "linter": { "enabled": true, "rules": { "recommended": true } },
-  "javascript": {
-    "formatter": {
-      "jsxQuoteStyle": "double",
-      "quoteProperties": "asNeeded",
-      "trailingCommas": "all",
-      "semicolons": "always",
-      "arrowParentheses": "always",
-      "bracketSameLine": false,
-      "quoteStyle": "double",
-      "attributePosition": "auto",
-      "bracketSpacing": true
-    }
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "formatter": {
+    "indentStyle": "space",
+    "lineWidth": 120
   },
   "html": { "formatter": { "selfCloseVoidElements": "always" } },
   "overrides": [
@@ -35,18 +14,19 @@
       "includes": ["**/*.astro"],
       "linter": {
         "rules": {
-          "correctness": {
-            "noUnusedImports": "off",
-            "noUnusedVariables": "off"
+          "style": {
+            "useConst": "off",
+            "useImportType": "off"
           },
-          "style": { "useConst": "off", "useImportType": "off" }
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
         }
       }
-    },
-    { "includes": ["*.astro"] }
+    }
   ],
   "assist": {
-    "enabled": true,
     "actions": { "source": { "organizeImports": "on" } }
   }
 }


### PR DESCRIPTION
Replaces the verbose `biome.json` with the leaner shared configuration used by tms-min-side, so both repos follow the same formatting and linting conventions.

**Key changes:**

- Schema pinned to `latest` instead of a specific version
- VCS integration enabled (`useIgnoreFile: true`) -- Biome now respects `.gitignore`
- Line width increased from 80 to 120
- Removed all explicit defaults (javascript formatter, linter enabled/recommended, etc.) -- Biome's built-in defaults cover these
- Removed redundant empty `{ "includes": ["*.astro"] }` override
- Added `files.includes` with exclusion for `.github/skills/**/scripts`