### PR TITLE
Remove compressHTML config from astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,10 +5,6 @@ import { defineConfig, envField } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   base: "/minside/utkast",
-  // Astro 7 changed the default to 'jsx', which strips spaces between inline
-  // elements. Pin to HTML-aware compression to keep rendered output identical
-  // to Astro 6 (no whitespace regressions in user-facing Norwegian copy).
-  compressHTML: true,
   build: {
     assetsPrefix: "https://cdn.nav.no/min-side/tms-utkast-frontend",
   },


### PR DESCRIPTION
The `compressHTML: true` option and its accompanying comment are no longer needed. This removes the pinned setting, letting Astro use its default HTML compression behavior.