### PR TITLE
fix: remove separate mock server from playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,21 +20,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
-  webServer: [
-    {
-      command: "pnpm mock",
-      url: "http://localhost:3000/utkast/v2/utkast",
-      reuseExistingServer: !process.env.CI,
-      timeout: 60_000,
+  webServer: {
+    command: `pnpm dev --port ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NODE_ENV: "development",
     },
-    {
-      command: `pnpm dev --port ${PORT}`,
-      url: baseURL,
-      reuseExistingServer: !process.env.CI,
-      timeout: 120_000,
-      env: {
-        NODE_ENV: "development",
-      },
-    },
-  ],
+  },
 });


### PR DESCRIPTION
After #179 migrated to `@navikt/astro-mocks`, the mock API runs as an Astro integration on the same port as the dev server. The Playwright config still referenced a standalone `pnpm mock` server on port 3000, which no longer exists -- causing e2e tests to fail.

This removes the obsolete `webServer` entry so Playwright only starts the Astro dev server, which now serves both the app and the mock endpoints.